### PR TITLE
Adicionar `.env`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,42 @@ Depois de baixar e instalar o node.js, você já está pronto para o próximo pa
 
 Depois de instalar o editor de texto e o node.js, precisamos instalar a biblioteca que conversa com a API do Discord, que neste caso, estamos usando o aoi.js.
 
-Para instalar o aoi.js, usaremos o comando abaixo:
+Para instalar aoi.js, usaremos o comando abaixo:
 
 ```batch
 npm install aoi.js
 ```
+
+Para instalar todas as packages usadas, usaremos o comando abaixo:
+```batch
+npm install
+```
+
 ##### ⚠️ Lembrando que você precisa de node.js de no mínimo 16.9.0 ou recente!
 
 ### 🔷 Quarto passo:
 
 Agora você pode ajudar no desenvolvimento do Winder, dar sugestões, reportar bugs e muito mais! **Happy coding!** 👨‍💻
+
+### 🏆 Bônus:
+
+<details>
+  <summary>Environment Variables para Visual Studio Code</summary>
+
+  ### Configurar `.env` no Visual Studio Code:
+  1. Crie um arquivo chamado `.env`
+  2. Após o passo acima, escreva na primeira linha `TOKEN="{token do bot}"`
+  3. Não mude a [6ª linha](https://github.com/WillSilvah/Winder/blob/main/index.js#L6) do [index.js](https://github.com/WillSilvah/Winder/blob/main/index.js)
+</details>
+<details>
+  <summary>Environment Variables para Replit</summary>
+
+  ### Configurar `.env` em Replit
+  1. Vá em seu projeto
+  2. Após o passo acima, vá em `Commands`
+  3. Feito isso, vá em `Secrets`
+     - Agora, defina `key` como `TOKEN` e o `value` com o token de seu bot.
+ </details>
 
 # 🛠️ Informações sobre o Winder
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const aoijs = require("aoi.js");
 const fs = require('fs');
 
 const bot = new aoijs.AoiClient({
-	token: "tokendobot",
+	token: process.env.TOKEN,
 	prefix: 'pw!',
     respondToBots: "false",
     intents: ["Guilds", "GuildMembers", "GuildBans", "GuildEmojisAndStickers", "GuildIntegrations", "GuildWebhooks", "GuildInvites", "GuildVoiceStates", "GuildPresences", "GuildMessages", "GuildMessageReactions", "GuildMessageTyping", "DirectMessages", "DirectMessageReactions", "DirectMessageTyping", "MessageContent"],


### PR DESCRIPTION
`.env` evita com que pessoas "hackeem" facilmente o token do bot, mesmo se tiver escondido ou não, eles conseguem.